### PR TITLE
feat: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,51 +1,74 @@
+# -------------------
+#   General
+# -------------------
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: pretty-format-json
-# -------------------
-#   Python-specific
-# -------------------
-# Type checking
--   repo: https://github.com/pre-commit/mirrors-mypy
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: pretty-format-json
+  # -------------------
+  #   Python-specific
+  # -------------------
+  # Type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.1
     hooks:
-    -   id: mypy
-# Format and lint
--   repo: https://github.com/psf/black
-    rev: 23.12.0
-    hooks:
-    -   id: black
--   repo: https://github.com/PyCQA/isort
+      - id: mypy
+  # Format and lint
+  - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
-    -   id: isort
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
     hooks:
-    -   id: flake8
-        args: ['--max-line-length', '120']
-# ------------------
-#   Git-specific
-# ------------------
-# Using this npm package: https://commitlint.js.org/#/
-# Adapted into pre-commit framework
-- repo: local
-  hooks:
-    - id: commitlint
-      name: commitlint
-      entry: ./config/commitlint.sh
-      language: system
-      pass_filenames: false
-# -------------------
-#      Security
-# -------------------
--   repo: https://github.com/PyCQA/bandit
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/myint/docformatter # Format Python doc strings
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+    args: [--in-place, --wrap-summaries=99, --wrap-descriptions=99]
+  # ------------------
+  #   Other formatters
+  # ------------------
+  # Format YAML files
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.6
+    hooks:
+      - id: prettier
+        types: [yaml]
+        exclude: "environment.yaml"
+  # Format bash files
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.2
+    hooks:
+      - id: shellcheck
+  # ------------------
+  #   Git-specific
+  # ------------------
+  # Using this npm package: https://commitlint.js.org/#/
+  # Adapted into pre-commit framework
+  - repo: local
+    hooks:
+      - id: commitlint
+        name: commitlint
+        entry: ./config/commitlint.sh
+        language: system
+        pass_filenames: false
+  # -------------------
+  #      Security
+  # -------------------
+  - repo: https://github.com/PyCQA/bandit
     rev: 1.7.6
     hooks:
-    -   id: bandit
-        args: ['--exclude', 'tests']
-# -------------------
+      - id: bandit
+        args: ["--exclude", "tests"]

--- a/config/commitlint.config.js
+++ b/config/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/config/commitlint.sh
+++ b/config/commitlint.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-# Extract commit messsage
+# 1. Extract commit messsage
 commit_message=$(git log -1 --pretty=%B)
 
-# Apply commitlint tool in CLI
+# 2. Check against allowed exceptions
+exceptions=( 'Initial commit' )
+for exception in "${exceptions[@]}"; do
+  if [[ "$commit_message" == "$exception" ]]; then
+    exit 0
+  fi
+done
+
+# 3. If no match found, apply commitlint tool in CLI
 echo "$commit_message" | commitlint --config config/commitlint.config.js


### PR DESCRIPTION
## Description

Added and refined template's pre-commit hooks

## Changes

* Features
  * Use [ruff](https://github.com/astral-sh/ruff) to format and lint Python code  (to speed up pre-commit hook runtimes)
  * Added formatters for bash, YAML, and Python doc strings
* Fixes
  *  Created list of allowed for exceptions during  commit listing $\rightarrow$ hook now passes on the default "Initial commit" message

## Checklist

- [x] My code follows [the style guidelines of this project](https://google.github.io/styleguide/pyguide.html)
- [x] I have commented my code, particularly in hard-to-understand areas, and updated [the project documentation](https://github.com/bellanich/python-ml-template/tree/main/docs) accordingly
- [x] New and existing unit tests pass locally with my changes
- [x] There are no `TODO` comments left in my code
