### PR TITLE
feat: simplify commitlint approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Rather than re-inventing the wheel, I've leveraged the following great resources
 * [Guide to making custom language badges](https://javascript.plainenglish.io/how-to-make-custom-language-badges-for-your-profile-using-shields-io-d2aeaf016b6b)
 * [Simple Icons's library of open source project logos](https://simpleicons.org/)
 * [Python's Official Logging Cookbook by Vinay Sajip](https://docs.python.org/3/howto/logging-cookbook.html)
+* [Conventional Commit Regex by marcojahn](https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c)
 
 <!-- * [GitHub Emoji Cheat Sheet](https://www.webpagefx.com/tools/emoji-cheat-sheet)
 * [Malven's Flexbox Cheatsheet](https://flexbox.malven.co/)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ This project leverages the power of the following frameworks and libraries. Refe
 
 * [![Static Badge][copier-badge-url]][copier-website]
 * [![Static Badge][pre-commit-badge-url]][pre-commit-website]
-* [![Static Badge][commitlint-badge-url]][commitlint-website]
 * [![Static Badge][conda-badge-url]][conda-website]
 * [![Static Badge][pytest-badge-url]][pytest-website]
 * [![Static Badge][github-actions-badge-url]][github-actions-website]
@@ -270,9 +269,7 @@ Rather than re-inventing the wheel, I've leveraged the following great resources
 <!-- Badges for tooling and frameworks  -->
 [pre-commit-badge-url]: https://img.shields.io/badge/-React%2520Router?style=for-the-badge&logo=precommit&logoColor=%23FAB040&label=precommit&color=gray&link=https%3A%2F%2Fpre-commit.com
 [pre-commit-website]: https://pre-commit.com
-[commitlint-badge-url]: https://img.shields.io/badge/-React%2520Router?style=for-the-badge&logo=commitlint&label=commitlint&labelColor=%23000000&color=%23000000&link=https%3A%2F%2Fcommitlint.js.org%2F%23%2F
-[commitlint-website]: https://commitlint.js.org/#/
-[copier-badge-url]: https://img.shields.io/badge/-React%2520Router?style=for-the-badge&logo=python&logoColor=orange&label=copier&labelColor=white&color=white&link=https%3A%2F%2Fcommitlint.js.org%2F%23%2F
+[copier-badge-url]: https://img.shields.io/badge/-React%2520Router?style=for-the-badge&logo=python&logoColor=orange&label=copier&labelColor=white&color=white&link=https%3A%2F%2F.js.org%2F%23%2F
 [copier-website]: https://copier.readthedocs.io/en/stable/
 [pytest-badge-url]: https://img.shields.io/badge/-ReactJS%2520?style=for-the-badge&logo=pytest&logoColor=%230A9EDC&label=PyTest&labelColor=gray&color=gray
 [pytest-website]: https://docs.pytest.org/en/7.4.x/contents.html

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -231,6 +231,7 @@ Rather than re-inventing the wheel, I've leveraged the following great resources
 * [Guide to making custom language badges](https://javascript.plainenglish.io/how-to-make-custom-language-badges-for-your-profile-using-shields-io-d2aeaf016b6b)
 * [Simple Icons's library of open source project logos](https://simpleicons.org/)
 * [Python's Official Cookbook by Vinay Sajip](https://docs.python.org/3/howto/logging-cookbook.html)
+* [Conventional Commit Regex by marcojahn](https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c)
 
 <!-- * [GitHub Emoji Cheat Sheet](https://www.webpagefx.com/tools/emoji-cheat-sheet)
 * [Malven's Flexbox Cheatsheet](https://flexbox.malven.co/)

--- a/config/commitlint.config.js
+++ b/config/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/config/commitlint.sh
+++ b/config/commitlint.sh
@@ -13,7 +13,7 @@ for exception in "${exceptions[@]}"; do
 done
 
 # 3. If no match found, apply commitlint tool in CLI
-# Refer to https://www.conventionalcommits.org/en/v1.0.0/ for additional guidance
+# Regex pattern taken from https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c
 REGEX_PATTERN='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([[:alnum:]._-]+\))?(!)?: ([[:alnum:]])+([[:space:][:print:]]*)|^Merge|^pick [a-f0-9]+ (.+)$|^Revert\s'
 if [[ ! $COMMIT_MESSAGE =~ $REGEX_PATTERN ]]; then
   echo "ERROR: Commit message does not follow the Conventional Commits format"

--- a/config/commitlint.sh
+++ b/config/commitlint.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 
 # 1. Extract commit messsage
-commit_message=$(git log -1 --pretty=%B)
+COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+echo "$COMMIT_MESSAGE"
 
 # 2. Check against allowed exceptions
 exceptions=( 'Initial commit' )
 for exception in "${exceptions[@]}"; do
-  if [[ "$commit_message" == "$exception" ]]; then
+  if [[ "$COMMIT_MESSAGE" == "$exception" ]]; then
     exit 0
   fi
 done
 
 # 3. If no match found, apply commitlint tool in CLI
-echo "$commit_message" | commitlint --config config/commitlint.config.js
+# Refer to https://www.conventionalcommits.org/en/v1.0.0/ for additional guidance
+REGEX_PATTERN='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([[:alnum:]._-]+\))?(!)?: ([[:alnum:]])+([[:space:][:print:]]*)|^Merge|^pick [a-f0-9]+ (.+)$|^Revert\s'
+if [[ ! $COMMIT_MESSAGE =~ $REGEX_PATTERN ]]; then
+  echo "ERROR: Commit message does not follow the Conventional Commits format"
+  echo "For Conventional Commits format specifications, please refer to https://www.conventionalcommits.org/en/v1.0.0/"
+  exit 1
+else
+  echo "Everything is okay!"
+fi

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,7 @@ channels:
 dependencies:
   - python
   - ipython
-  - black
-  - flake8
+  - ruff
   - isort
   - pre-commit
   - pytest


### PR DESCRIPTION
## Description

Replaced use of [Javascript commitlint CLI ](https://commitlint.js.org) with a [manual regex approach](https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c)

* **Why?** Javascript CLI was adding too much complexity to commitlint pre-commit hook

## Changes

* Features
  * Updated local `commitlint.sh` script to use regex patterns to validate commit message
  * Deleted Javascript configs
  * Updated docs to credit  original [source for Conventional Commit regex pattern](https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c)
* Enhancements
  * Updated base definition of Python dependencies to use `ruff` instead of `flake8` and `black` 

## Checklist

- [x] My code follows [the style guidelines of this project](https://google.github.io/styleguide/pyguide.html)
- [x] I have commented my code, particularly in hard-to-understand areas, and updated [the project documentation](https://github.com/bellanich/python-ml-template/tree/main/docs) accordingly
- [x] New and existing unit tests pass locally with my changes
- [x] There are no `TODO` comments left in my code
